### PR TITLE
fixed ByteStream$readDataReference

### DIFF
--- a/ByteStream/index.js
+++ b/ByteStream/index.js
@@ -83,7 +83,8 @@ class ByteStream {
   }
 
   readDataReference () {
-    return [ this.readVInt(), this.readVInt() ] 
+    const x = this.readVInt();
+    return [ x, x === 0 ? 0 : this.readVInt() ] 
   }
 
   writeDataReference (a1, a2) {


### PR DESCRIPTION
readDataReference could have only 1 vint if  it returns 0. for example reading skin id in AskForBattleEndMessage for a bot.